### PR TITLE
fix: polar area charts not rendering

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -60,7 +60,7 @@ export function chart(
     {},
 ): string {
   Object.assign(options, {
-    animation: undefined,
+    animation: false,
     events: [],
     responsive: false,
   });

--- a/examples/routes/index.tsx
+++ b/examples/routes/index.tsx
@@ -82,6 +82,29 @@ export default function Home() {
           class="mx-auto my-4 h-96"
           alt="an example chart provided as an image"
         />
+        <h1 class="text(xl gray-600) font-medium mt-4">
+          Polar Area Chart - Inline
+        </h1>
+        <Chart
+          type="polarArea"
+          options={{ devicePixelRatio: 1 }}
+          data={{
+            labels: ["Red", "Orange", "Yellow", "Green", "Blue"],
+            datasets: [
+              {
+                label: "Dataset 1",
+                data: numbers(pieCfg),
+                backgroundColor: [
+                  ChartColors.Red,
+                  ChartColors.Orange,
+                  ChartColors.Yellow,
+                  ChartColors.Green,
+                  ChartColors.Blue,
+                ],
+              },
+            ],
+          }}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
Certain charts (at least "polarArea" would error when rendering if animations was set to `undefined`, where if set to `false` the charts rendered).