### PR TITLE
feat: expose ChartJS global defaults

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -2,6 +2,9 @@
 
 import { ChartJs, Rect2D, SvgCanvas, SvgCanvas2DGradient } from "./deps.ts";
 
+/** Underlying ChartJS global defaults which can be modified. */
+export const globalDefaults = ChartJs.defaults.global;
+
 /** The set of chart options that are supported. Unsupported or fixed values
  * are omitted from the underlying {@linkcode ChartJs.ChartOptions}. */
 export type ChartOptions = Omit<

--- a/mod.ts
+++ b/mod.ts
@@ -51,5 +51,9 @@
  */
 
 export { Chart } from "./Chart.tsx";
-export { type ChartConfiguration, type ChartOptions } from "./core.ts";
+export {
+  type ChartConfiguration,
+  type ChartOptions,
+  globalDefaults,
+} from "./core.ts";
 export { renderChart } from "./render.ts";


### PR DESCRIPTION
There are some options that can't be set on individual charts and have to be set on the global defaults.  This exports this option from the ChartJS library.