### PR TITLE
feat: expose plugin interface

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -50,14 +50,17 @@ interface SvgCanvasCanvas {
   };
 }
 
+/** Global plugins for the underlying Chart.js library. */
+export const plugins = ChartJs.plugins;
+
 /** Render a chart, returning a SVG string representation of the chart.
  *
  * This is a lower level function, where the `Chart` component and `renderChart`
  * are intended for use within a Fresh application.
  */
 export function chart(
-  { width = 768, height = 384, type, data, options = {} }: ChartConfiguration =
-    {},
+  { width = 768, height = 384, type, data, options = {}, plugins }:
+    ChartConfiguration = {},
 ): string {
   Object.assign(options, {
     animation: false,
@@ -78,7 +81,7 @@ export function chart(
   globalThis.CanvasGradient = SvgCanvas2DGradient as typeof CanvasGradient;
 
   try {
-    new ChartJs.Chart(el, { type, data, options });
+    new ChartJs.Chart(el, { type, data, options, plugins });
   } finally {
     if (savedGradient) {
       globalThis.CanvasGradient = savedGradient;

--- a/mod.ts
+++ b/mod.ts
@@ -51,5 +51,5 @@
  */
 
 export { Chart } from "./Chart.tsx";
-export { type ChartConfiguration, type ChartOptions } from "./core.ts";
+export { type ChartConfiguration, type ChartOptions, plugins } from "./core.ts";
 export { renderChart } from "./render.ts";


### PR DESCRIPTION
This also fixes and issue where the plugin property was not being passed to the underlying Chart.js chart constructor.