### PR TITLE
feat: update to ChartJs v4

### DIFF
--- a/Chart.test.tsx
+++ b/Chart.test.tsx
@@ -7,7 +7,7 @@ import { Chart } from "./Chart.tsx";
 Deno.test({
   name: "Chart - renders",
   fn() {
-    const actual = render(<Chart />);
+    const actual = render(<Chart data={{ datasets: [] }} />);
     assertStringIncludes(
       actual,
       `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="768px" height="384px" viewBox="0 0 768 384">`,

--- a/Chart.tsx
+++ b/Chart.tsx
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { chart, type ChartConfiguration } from "./core.ts";
+import { type ChartJs } from "./deps.ts";
 
 /** A JSX component which is can be used to server side render a chart inline
  * within a page.
@@ -46,6 +47,10 @@ import { chart, type ChartConfiguration } from "./core.ts";
  * }
  * ```
  */
-export function Chart(opts: ChartConfiguration) {
+export function Chart<
+  TType extends ChartJs.ChartType = ChartJs.ChartType,
+  TData = ChartJs.DefaultDataPoint<TType>,
+  TLabel = unknown,
+>(opts: ChartConfiguration<TType, TData, TLabel>) {
   return <span dangerouslySetInnerHTML={{ __html: chart(opts) }}></span>;
 }

--- a/deps.ts
+++ b/deps.ts
@@ -6,8 +6,8 @@
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-export { default as colorLib } from "https://esm.sh/stable/@kurkle/color@0.2.1";
-export { default as ChartJs } from "https://esm.sh/stable/chart.js@2.9.3";
+export { default as colorLib } from "https://esm.sh/stable/@kurkle/color@0.3.1";
+export * as ChartJs from "https://esm.sh/stable/chart.js@4.0.1/auto";
 export {
   Rect2D,
   SvgCanvas,

--- a/examples/routes/index.tsx
+++ b/examples/routes/index.tsx
@@ -28,10 +28,7 @@ export default function Home() {
         <h1 class="text(xl gray-600) font-medium mt-4">Bar Chart - Inline</h1>
         <Chart
           type="bar"
-          options={{
-            devicePixelRatio: 1,
-            scales: { xAxes: [{ stacked: true }], yAxes: [{ stacked: true }] },
-          }}
+          options={{ devicePixelRatio: 1 }}
           data={{
             labels: months(barCfg),
             datasets: [

--- a/mod.ts
+++ b/mod.ts
@@ -51,5 +51,10 @@
  */
 
 export { Chart } from "./Chart.tsx";
-export { type ChartConfiguration, type ChartOptions } from "./core.ts";
+export {
+  type ChartConfiguration,
+  type ChartOptions,
+  defaults,
+  plugins,
+} from "./core.ts";
 export { renderChart } from "./render.ts";

--- a/render.ts
+++ b/render.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { chart, type ChartConfiguration } from "./core.ts";
+import { type ChartJs } from "./deps.ts";
 
 /** Render a chart, based on the configuration, returning the chart as an SVG
  * {@linkcode Response}.
@@ -45,7 +46,11 @@ import { chart, type ChartConfiguration } from "./core.ts";
  * };
  * ```
  */
-export function renderChart(configuration?: ChartConfiguration): Response {
+export function renderChart<
+  TType extends ChartJs.ChartType = ChartJs.ChartType,
+  TData = ChartJs.DefaultDataPoint<TType>,
+  TLabel = unknown,
+>(configuration?: ChartConfiguration<TType, TData, TLabel>): Response {
   return new Response(chart(configuration), {
     headers: { "content-type": "image/svg+xml" },
   });

--- a/test.ts
+++ b/test.ts
@@ -8,6 +8,6 @@ Deno.test({
   fn() {
     assertEquals(typeof mod.Chart, "function");
     assertEquals(typeof mod.renderChart, "function");
-    assertEquals(Object.entries(mod).length, 2);
+    assertEquals(Object.entries(mod).length, 4);
   },
 });


### PR DESCRIPTION
Previously I had tried to use ChartJs v3, but there were several issues which were not straight forward to resolve, but with the release of ChartJs v4, there was only one minor change that needed to be made to support it, so this brings it up to date with the latest release of ChartJs.