### PR TITLE
chore: set lock false

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,5 +7,6 @@
   "tasks": {
     "examples": "cd examples && deno task start",
     "test": "deno test"
-  }
+  },
+  "lock": false
 }

--- a/examples/deno.json
+++ b/examples/deno.json
@@ -6,5 +6,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
-  }
+  },
+  "lock": false
 }


### PR DESCRIPTION
This PR sets "lock" false to disable lock file generation. Currently esm.sh dependencies can be changed sometimes and lock file doesn't work well in those cases.