### PR TITLE
feat: add svgStyle and svgClass props

### DIFF
--- a/Chart.test.tsx
+++ b/Chart.test.tsx
@@ -14,3 +14,28 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "Chart - renders with svgClass, svgStyle",
+  fn() {
+    let actual = render(
+      <Chart
+        data={{ datasets: [] }}
+        svgClass="w-full"
+        svgStyle="width: 100%;"
+      />,
+    );
+    assertStringIncludes(
+      actual,
+      `<svg class="w-full" style="width: 100%;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="768px" height="384px" viewBox="0 0 768 384">`,
+    );
+
+    actual = render(
+      <Chart data={{ datasets: [] }} svgClass={`"`} svgStyle={`"`} />,
+    );
+    assertStringIncludes(
+      actual,
+      `<svg class="&quot;" style="&quot;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="768px" height="384px" viewBox="0 0 768 384">`,
+    );
+  },
+});

--- a/Chart.tsx
+++ b/Chart.tsx
@@ -52,5 +52,9 @@ export function Chart<
   TData = ChartJs.DefaultDataPoint<TType>,
   TLabel = unknown,
 >(opts: ChartConfiguration<TType, TData, TLabel>) {
+  if (opts.svgClass) {
+    // Calculates span with the given svg class to make twind aware of the given class
+    const _span = <span class={opts.svgClass}></span>;
+  }
   return <span dangerouslySetInnerHTML={{ __html: chart(opts) }}></span>;
 }

--- a/core.ts
+++ b/core.ts
@@ -63,6 +63,10 @@ export interface ChartConfiguration<
   options?: ChartOptions;
   /** Chart plugins to be registered for the chart. */
   plugins?: ChartJs.Plugin[];
+  /** CSS class for the <svg> element of the chart. */
+  svgClass?: string;
+  /** CSS style for the <svg> element of the chart */
+  svgStyle?: string;
 }
 
 interface SvgCanvasExtras {
@@ -84,8 +88,16 @@ export function chart<
   TData = ChartJs.DefaultDataPoint<TType>,
   TLabel = unknown,
 >(
-  { width = 768, height = 384, type = "bar", data, options = {}, plugins }:
-    ChartConfiguration<TType, TData, TLabel> = { data: { datasets: [] } },
+  {
+    width = 768,
+    height = 384,
+    type = "bar",
+    data,
+    options = {},
+    plugins,
+    svgClass,
+    svgStyle,
+  }: ChartConfiguration<TType, TData, TLabel> = { data: { datasets: [] } },
 ): string {
   Object.assign(options, {
     animation: false,
@@ -113,5 +125,20 @@ export function chart<
     }
   }
 
-  return ctx.render(new Rect2D(0, 0, width, height), "px");
+  let svg = ctx.render(new Rect2D(0, 0, width, height), "px");
+
+  if (svgStyle) {
+    svg = svg.replace(
+      "<svg ",
+      `<svg style="${svgStyle.replaceAll('"', "&quot;")}" `,
+    );
+  }
+  if (svgClass) {
+    svg = svg.replace(
+      "<svg ",
+      `<svg class="${svgClass.replaceAll('"', "&quot;")}" `,
+    );
+  }
+
+  return svg;
 }

--- a/examples/routes/index.tsx
+++ b/examples/routes/index.tsx
@@ -49,6 +49,7 @@ export default function Home() {
               },
             ],
           }}
+          svgClass="w-full"
         />
         <h1 class="text(xl gray-600) font-medium mt-4">Pie Chart - Inline</h1>
         <Chart
@@ -70,6 +71,7 @@ export default function Home() {
               },
             ],
           }}
+          svgStyle="width: 100%;"
         />
         <h1 class="text(xl gray-600) font-medium mt-4">
           Line Chart - Image Tag
@@ -101,6 +103,7 @@ export default function Home() {
               },
             ],
           }}
+          svgClass="w-full"
         />
       </div>
     </>


### PR DESCRIPTION
partially addresses #11 

Now `Chart` component accepts `svgStyle` and `svgClass` props and thoses are assigned to `style`, `class` attributes of `<svg>` element.

This will be useful to solve mobile layout issues, such as https://github.com/denoland/saaskit/issues/251

Currenlt saaskit uses a workaround like this https://github.com/denoland/saaskit/pull/259/files

With this change and `svgClass="w-full"` applied, the example page chart renders like the below:

BEFORE
<img width="443" alt="Screenshot 2023-06-29 at 20 35 55" src="https://github.com/denoland/fresh_charts/assets/613956/0fd5d7c7-0863-4d53-9003-283d4417f437">

AFTER
<img width="448" alt="Screenshot 2023-06-29 at 20 35 32" src="https://github.com/denoland/fresh_charts/assets/613956/de6dffea-475d-43f9-abd8-d1bde7c13214">

cc @iuioiua