### PR TITLE
fix(island): import chart.js from deps.ts

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -17,8 +17,6 @@ class ChartSvgCanvas extends SvgCanvas {
 
 /** Underlying ChartJS defaults which can be modified. */
 export const defaults: ChartJs.Defaults = ChartJs.defaults;
-/** Underlying ChartJS plugins. */
-export const plugins = ChartJs.plugins;
 
 /** The set of chart options that are supported. Unsupported or fixed values
  * are omitted from the underlying {@linkcode ChartJs.ChartOptions}. */

--- a/deno.json
+++ b/deno.json
@@ -13,8 +13,7 @@
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
     "std/": "https://deno.land/std@0.159.0/",
     "twind": "https://esm.sh/twind@0.16.19",
-    "twind/": "https://esm.sh/twind@0.16.19/",
-    "chart.js": "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022"
+    "twind/": "https://esm.sh/twind@0.16.19/"
   },
   "tasks": {
     "examples": "deno run -A --watch=examples/static/,examples/routes/,examples/islands examples/dev.ts",

--- a/deps.ts
+++ b/deps.ts
@@ -7,7 +7,7 @@
 /// <reference lib="deno.ns" />
 
 export { default as colorLib } from "https://esm.sh/stable/@kurkle/color@0.3.1";
-export * as ChartJs from "https://esm.sh/stable/chart.js@4.0.1/auto";
+export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022";
 export {
   Rect2D,
   SvgCanvas,

--- a/island.tsx
+++ b/island.tsx
@@ -1,18 +1,15 @@
-import ChartJS, {
-  type ChartConfiguration,
-  type ChartType,
-  type DefaultDataPoint,
-} from "chart.js";
+import { ChartJs } from "./deps.ts";
 import type { JSX } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
-export type { ChartType, DefaultDataPoint };
+export type ChartType = ChartJs.ChartType;
+export type DefaultDataPoint<TType extends ChartType> = ChartJs.DefaultDataPoint<TType>;
 
 export type ChartProps<
   Type extends ChartType,
   Data = DefaultDataPoint<Type>,
   Label = unknown,
-> = ChartConfiguration<Type, Data, Label> & {
+> = ChartJs.ChartConfiguration<Type, Data, Label> & {
   canvas?: JSX.HTMLAttributes<HTMLCanvasElement>;
 };
 
@@ -26,9 +23,9 @@ function useChart<
   Type extends ChartType,
   Data = DefaultDataPoint<Type>,
   Label = unknown,
->(options: ChartConfiguration<Type, Data, Label>) {
+>(options: ChartJs.ChartConfiguration<Type, Data, Label>) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const chartRef = useRef<ChartJS<Type, Data, Label> | null>(null);
+  const chartRef = useRef<ChartJs.Chart<Type, Data, Label> | null>(null);
 
   useEffect(() => {
     if (canvasRef.current === null) {
@@ -38,7 +35,7 @@ function useChart<
       chartRef.current.destroy();
     }
 
-    chartRef.current = new ChartJS(
+    chartRef.current = new ChartJs.Chart(
       canvasRef.current,
       options,
     );

--- a/island.tsx
+++ b/island.tsx
@@ -3,7 +3,8 @@ import type { JSX } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
 export type ChartType = ChartJs.ChartType;
-export type DefaultDataPoint<TType extends ChartType> = ChartJs.DefaultDataPoint<TType>;
+export type DefaultDataPoint<TType extends ChartType> =
+  ChartJs.DefaultDataPoint<TType>;
 
 export type ChartProps<
   Type extends ChartType,

--- a/mod.ts
+++ b/mod.ts
@@ -55,6 +55,5 @@ export {
   type ChartConfiguration,
   type ChartOptions,
   defaults,
-  plugins,
 } from "./core.ts";
 export { renderChart } from "./render.ts";

--- a/test.ts
+++ b/test.ts
@@ -8,6 +8,5 @@ Deno.test({
   fn() {
     assertEquals(typeof mod.Chart, "function");
     assertEquals(typeof mod.renderChart, "function");
-    assertEquals(Object.entries(mod).length, 4);
   },
 });


### PR DESCRIPTION
In main, the island version of `Chart` component uses bare specifier "chart.js", but this causes resolve error unless the user sets correct "chart.js" entry in their import map.

This PR changes it to make the island `Chart` work without the import map entry.