### PR TITLE
fix(island): add dedicated file for ssr deps

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -1,6 +1,7 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { ChartJs, Rect2D, SvgCanvas, SvgCanvas2DGradient } from "./deps.ts";
+import { ChartJs } from "./deps.ts";
+import { Rect2D, SvgCanvas, SvgCanvas2DGradient } from "./deps_server.ts";
 
 class ChartSvgCanvas extends SvgCanvas {
   public override clearRect(x: number, y: number, w: number, h: number): void {

--- a/deps.ts
+++ b/deps.ts
@@ -7,7 +7,7 @@
 /// <reference lib="deno.ns" />
 
 export { default as colorLib } from "https://esm.sh/stable/@kurkle/color@0.3.1";
-export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022";
+export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto";
 export {
   Rect2D,
   SvgCanvas,

--- a/deps.ts
+++ b/deps.ts
@@ -6,10 +6,10 @@
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-export { default as colorLib } from "https://esm.sh/stable/@kurkle/color@0.3.1";
-export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto";
+export { default as colorLib } from "https://esm.sh/stable/@kurkle/color@0.3.1?target=es2022";
+export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022";
 export {
   Rect2D,
   SvgCanvas,
   SvgCanvas2DGradient,
-} from "https://esm.sh/stable/red-agate-svg-canvas@0.5.0";
+} from "https://esm.sh/stable/red-agate-svg-canvas@0.5.0?target=es2022";

--- a/deps_server.ts
+++ b/deps_server.ts
@@ -6,4 +6,9 @@
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
 
-export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022";
+export { default as colorLib } from "https://esm.sh/stable/@kurkle/color@0.3.1";
+export {
+  Rect2D,
+  SvgCanvas,
+  SvgCanvas2DGradient,
+} from "https://esm.sh/stable/red-agate-svg-canvas@0.5.0";

--- a/island.deps.ts
+++ b/island.deps.ts
@@ -1,9 +1,0 @@
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-
-/// <reference no-default-lib="true" />
-/// <reference lib="dom" />
-/// <reference lib="dom.iterable" />
-/// <reference lib="dom.asynciterable" />
-/// <reference lib="deno.ns" />
-
-export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022";

--- a/island.deps.ts
+++ b/island.deps.ts
@@ -1,0 +1,9 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+/// <reference no-default-lib="true" />
+/// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
+/// <reference lib="dom.asynciterable" />
+/// <reference lib="deno.ns" />
+
+export * as ChartJs from "https://esm.sh/stable/chart.js@4.3.0/auto?target=es2022";

--- a/island.tsx
+++ b/island.tsx
@@ -1,3 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
 import { ChartJs } from "./deps.ts";
 import type { JSX } from "preact";
 import { useEffect, useRef } from "preact/hooks";

--- a/island.tsx
+++ b/island.tsx
@@ -1,4 +1,4 @@
-import { ChartJs } from "./island.deps.ts";
+import { ChartJs } from "./deps.ts";
 import type { JSX } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 

--- a/island.tsx
+++ b/island.tsx
@@ -1,4 +1,4 @@
-import { ChartJs } from "./deps.ts";
+import { ChartJs } from "./island.deps.ts";
 import type { JSX } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 

--- a/utils.ts
+++ b/utils.ts
@@ -1,6 +1,6 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { colorLib } from "./deps.ts";
+import { colorLib } from "./deps_server.ts";
 
 /** A set of CSS RGB colors which can be used with charts. */
 export enum ChartColors {


### PR DESCRIPTION
follow up on #17.

the island examples on https://fresh-charts.deno.dev/ are currently broken.
in the browser console, it shows the following error message:
```
Uncaught TypeError: Failed to resolve module specifier "buffer". Relative references must start with either "/", "./", or "../".
```

this is caused by the migration of the island's chart.js dependency into `dep.ts`, as some of the server side deps rely on `node:buffer`.

~~this pr is adding an explicit `?target=2022` param to all of them to resolve the issue.~~

this pr is adding a dedicated `deps_server.ts` file to the project.