### PR TITLE
fix: invalid JS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ router page itself.
 **/islands/chart.tsx**
 
 ```tsx
-import { Chart as default } from "$fresh_charts/island.tsx";
+import Chart from "$fresh_charts/island.tsx";
 ```
 
 **/routes/index.tsx**


### PR DESCRIPTION
There is no `import { Foo as default } from ".."` in JS. `default` cannot be used there as a keyword.